### PR TITLE
fixed duplication in board

### DIFF
--- a/src/components/Garden.tsx
+++ b/src/components/Garden.tsx
@@ -9,6 +9,7 @@ import { Container, Form } from "react-bootstrap";
 import Draggable from "react-draggable";
 import { Plant } from "../interfaces/plant";
 import Prop from "./Prop";
+import PropsInBoard from "./PropsInBoard";
 
 class Garden extends React.Component<{
     selectElement: (id: number) => void;
@@ -95,7 +96,7 @@ class Garden extends React.Component<{
                         return (
                             <Draggable bounds="parent" {...dragHandlers}>
                                 <div className="box">
-                                    <Prop
+                                    <PropsInBoard
                                         plant={prop}
                                         selectElement={selectElement}
                                         scaleValue={scaleValue}

--- a/src/components/PropsInBoard.tsx
+++ b/src/components/PropsInBoard.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useState } from "react";
+import { useDrag } from "react-dnd";
+import { ItemTypes } from "../DnD-demo/constants";
+import { Plant } from "../interfaces/plant";
+import { PlantDescriber } from "./PlantDescriber";
+
+function Prop({
+    plant,
+    selectElement,
+    scaleValue
+}: {
+    plant: Plant;
+    selectElement: (id: number) => void;
+    scaleValue: number;
+}): JSX.Element {
+    const makeid = (length: number) => {
+        let result = "";
+        const characters =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        const charactersLength = characters.length;
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(
+                Math.floor(Math.random() * charactersLength)
+            );
+        }
+        return result;
+    };
+
+    return (
+        <div>
+            <img
+                id={plant.id.toString()}
+                src={plant.sideImage}
+                alt={plant.species}
+                style={{
+                    width: `${(plant.size / scaleValue) * 800}px`,
+                    height: `${(plant.size / scaleValue) * 800}px`
+                }}
+                onClick={() => {
+                    selectElement(plant.id);
+                }}
+            />
+        </div>
+    );
+}
+
+export default Prop;


### PR DESCRIPTION
items in board do not duplicate themselves when dragging a picture. Involves the use of a new component, which is identical to Props but does not have drag.